### PR TITLE
Add bang methods to update commands, allowing bypass of exclusion dir…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ at least `Vim70` (including `Vim80`) with something like
 [pathogen](https://github.com/tpope/vim-pathogen).
 
 ### Vim80 + Packages
-To install with `Vim80`, using the `packages` feature (replace
-PACKAGE_DIRECTORY with the package name)
+To install with `Vim80`, using the `packages` feature.
 
 ```bash
 cd ~/.vim/pack/PACKAGE_DIRECTORY/start/
 git clone https://github.com/evanthegrayt/update-plugins.git
 ```
+
+Make sure to replace `PACKAGE_DIRECTORY` with the package name!
 
 ### Pathogen
 To install using pathogen:
@@ -35,46 +36,25 @@ cd ~/.vim/bundle/
 git clone https://github.com/evanthegrayt/update-plugins.git
 ```
 
-## Quick Start
-By default, three commands are available:
-
-```vim
-:UpdateAllPlugins " Loop through all plugins and attempt to update them
-:UpdateSinglePlugin [PLUGIN] " Attempt to update the specified [PLUGIN]
-:ListAllPlugins " List all plugins, and whether or not they're a git repository
-```
-
-To change the default behavior, or to add custom mappings, see the
-`Configuration` section below.
-
 ## Features
 This plugin attempts to update your `vim` plugins, either one at a time using
 `:UpdateSinglePlugin [PLUGIN]`, or all at once using `:UpdateAllPlugins`. To use
 the former, for now, you must specify the directory name of the plugin. To see
-a list of available plugins, use `:ListAllPlugins`. Also, for now, if you call
-`:UpdateSinglePlugin` and the plugin is in your exclude list, it _will_ update
-the plugin, since you called it by name. This 'feature' may change in the
-future.
+a list of available plugins, use `:ListAllPlugins`.
 
 If you're running version 8 or higher, it will first look in
 `~/.vim/pack/*/start/`. If you're running version 7 or higher, or you're not
-using the `pack` directory structure, it will look in `~/.vim/bundle/`
+using the `pack` directory structure, it will look in `~/.vim/bundle/`. You are
+able to set a custom directory if yours is in a different location.
 
-Once finished, the plugin will `echom` the results. To turn this feature off,
-see the `Configuration` section below.
+You can create a list of plugins to exclude from updating. Calling either of the
+Update commands with a bang (!) will ignore the exclusion list.
+
+Once finished, the plugin will `echom` the results. You are able to turn this
+off if you don't like the output.
 
 ## Configuration
 If you don't like the default behavior, there are some modifications available.
-
-### Mappings
-If you do not like the default commands, you can create your own mappings. For
-example, you can add the following lines to your `~/.vimrc`:
-
-```vim
-nnoremap <leader>uap :call update_plugins#update_all_plugins()<CR>
-nnoremap <leader>usp :call update_plugins#update_single_plugin()<CR>
-nnoremap <leader>lap :call update_plugins#list_all_plugins()<CR>
-```
 
 ### Plugin Directory Location
 To manually set the location of your plugin directory, add the following line to
@@ -89,12 +69,14 @@ wildcard. The `Vim80` example for Mac would be (and is, by default):
 `/Users/USER/.vim/pack/*/start/`
 
 ### Excluding a Directory
-By default, the plugin attempts to update all directories. If there are plugins
+By default, the plugin attempts to update any repository. If there are plugins
 that you don't want updated, you can create a list of plugins to not update.
 Please note that the list elements must match the directory name of the plugin.
+Also note that calling `:UpdateSinglePlugin!` and `:UpdateAllPlugins!` (with the
+bang) will ignore this list!
 
 ```vim
-let g:update_plugins_exclude = ['plugin_name']
+let g:update_plugins_exclude = ['plugin_to_exclude', 'second_plugin_to_exclude']
 ```
 
 ### Pulling from Git
@@ -109,6 +91,16 @@ following line to your `~/.vimrc`:
 
 ```vim
 let g:update_plugins_git_command = 'git pull origin master'
+```
+
+### Commands
+If you do not like the default commands, you can create your own command names.
+For example, you could add the following lines to your `~/.vimrc`:
+
+```vim
+command! PlugList call update_plugins#list_all_plugins()
+command! -bang PlugUpdateAll call update_plugins#update_all_plugins(<bang>0)
+command! -nargs=1 PlugUpdate call update_plugins#update_single_plugin(<bang>0, '<args>')
 ```
 
 ### Messages

--- a/autoload/update_plugins.vim
+++ b/autoload/update_plugins.vim
@@ -5,7 +5,7 @@
 
 " PUBLIC API
 
-function! update_plugins#update_all_plugins()
+function! update_plugins#update_all_plugins(bang)
   call s:create_arrays()
   let l:plugindirs = split(globpath(g:update_plugins_directory, '*', 0))
   call filter(l:plugindirs, 'isdirectory(v:val)')
@@ -15,7 +15,7 @@ function! update_plugins#update_all_plugins()
     return
   endif
   for l:plugindir in l:plugindirs
-    if s:is_excluded(fnamemodify(l:plugindir, ':t'))
+    if !a:bang && s:is_excluded(fnamemodify(l:plugindir, ':t'))
       call add(s:excluded, fnamemodify(l:plugindir, ':t'))
     elseif !s:update(l:plugindir)
       call s:warn("Script was stopped before it was finished!")
@@ -29,15 +29,17 @@ function! update_plugins#update_all_plugins()
   endif
 endfunction
 
-function! update_plugins#update_single_plugin(plugindir)
+function! update_plugins#update_single_plugin(bang, plugindir)
   call s:create_arrays()
-  let l:plugin = expand(g:update_plugins_directory . a:plugindir, 0)
-  if isdirectory(l:plugin)
-    call s:update(l:plugin)
+  let l:plugindir = expand(g:update_plugins_directory . a:plugindir, 0)
+  if !a:bang && s:is_excluded(a:plugindir)
+    call s:warn("Directory " . a:plugindir . " excluded by user!")
+  elseif isdirectory(l:plugindir)
+    call s:update(l:plugindir)
+    call s:print_results()
   else
     call s:warn(a:plugindir . " is not a directory!")
   endif
-  call s:print_results()
 endfunction
 
 function! update_plugins#list_all_plugins()

--- a/doc/update_plugins.txt
+++ b/doc/update_plugins.txt
@@ -3,7 +3,7 @@ update-plugins UpdatePlugins update_plugins
 
 ================================================================================
 Author:  Evan Gray <egray1985@gmail.com>                         *UpdatePlugins*
-License: Same terms as Vim itself (see |license|)
+License: MIT License
 
 ================================================================================
 INTRODUCTION                                        *UpdatePlugins-introduction*
@@ -16,13 +16,16 @@ QUICK-START                                          *UpdatePlugins-quick-start*
 
 By default, you can update all of your plugins by calling:
 >
-    :UpdateAllPlugins
+    :UpdateAllPlugins[!]
 <
 To update a single plugin, call:
 >
-    :UpdateSinglePlugin <plugin>
+    :UpdateSinglePlugin[!] <plugin>
 <
 Note that '<plugin>' is the directory name of the plugin.
+
+Adding the bang (!) to the end of these commands tells the plugin to ignore the
+exclusion list.
 
 To get a list of all your plugins, call:
 >
@@ -49,15 +52,15 @@ CONFIGURATION                                      *UpdatePlugins-configuration*
 
 This plugin comes with the following commands:
 >
-    :UpdateAllPlugins
-    :UpdateSinglePlugin <plugin>
+    :UpdateAllPlugins[!]
+    :UpdateSinglePlugin[!] <plugin>
     :ListAllPlugins
 <
 If you want to create your own mappings, you can use the following examples:
 >
-    :nnoremap <leader>UAP :call update_plugins#update_all_plugins()<CR>
-    :nnoremap <leader>USP :call update_plugins#update_single_plugin()<CR>
-    :nnoremap <leader>LAP :call update_plugins#list_all_plugins()<CR>
+    command! PlugList call update_plugins#list_all_plugins()
+    command! -bang PlugUpdateAll call update_plugins#update_all_plugins(<bang>0)
+    command! -bang -nargs=1 PlugUpdate call update_plugins#update_single_plugin(<bang>0, '<args>')
 <
 If you're not using one of the two supported directory structures, you can set
 the location putting the following line in your '.vimrc'
@@ -68,12 +71,12 @@ If you're using a `pack`-like directory structure, use the `*` wildcard:
 >
     let g:update_plugins_directory = '/full/path/to/pack/*/start/'
 <
-If, for whatever reason, you don't want a plugin to be updated, you cann add
-this line in your '.vimrc'
+If you don't want a plugin to be updated, you can add this line in your '.vimrc'
 >
-    let g:update_plugins_exclude = ['plugin']
+    let g:update_plugins_exclude = ['plugin_to_exclude', 'second_plugin_to_exclude']
 <
-Note that 'plugin' is the directory name of the plugin.
+Note that 'plugin' is the directory name of the plugin. If you need to update
+plugins that are in the exclusion list, call the command with a bang (!).
 
 If you don't like the results lists printing when the plugin finishes, you can
 disable the behavior by putting the following line in your '.vimrc'

--- a/plugin/update_plugins.vim
+++ b/plugin/update_plugins.vim
@@ -3,7 +3,7 @@
 " Description: Plugin to update git repo plugins
 " Date: October 2017
 
-if exists('g:update_plugins_is_loaded')
+if exists('g:update_plugins_is_loaded') || &cp
   finish
 elseif v:version < 700
   echomsg "UpdatePlugins: Vim version [ " . v:version . " not supported..."
@@ -37,7 +37,7 @@ if !exists("g:update_plugins_ignore")
 endif
 
 command! ListAllPlugins call update_plugins#list_all_plugins()
-command! UpdateAllPlugins call update_plugins#update_all_plugins()
-command! -nargs=+ UpdateSinglePlugin
-      \ call update_plugins#update_single_plugin('<args>')
+command! -bang UpdateAllPlugins call update_plugins#update_all_plugins(<bang>0)
+command! -bang -nargs=1 UpdateSinglePlugin
+      \ call update_plugins#update_single_plugin(<bang>0, '<args>')
 


### PR DESCRIPTION
# Add bang methods
New functionality allows bangs as command arguments, which will tell the functions to bypass the exclusion list.
# Update documentation
Update vim docs and readme
# Various small changes
Other improvements, such as a custom error message when the user tries to update a single plugin that is excluded.
# Issue
https://github.com/evanthegrayt/vim-update-plugins/issues/8